### PR TITLE
Update libtest-mimic to 0.5.2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,8 +38,8 @@ jobs:
     strategy:
       matrix:
         os: [ ubuntu-latest, macos-latest, windows-latest ]
-        # 1.56 is the MSRV
-        rust-version: [ 1.56, stable ]
+        # 1.58 is the MSRV
+        rust-version: [ 1.58, stable ]
       fail-fast: false
     env:
       RUSTFLAGS: -D warnings

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ categories = ["development-tools::testing"]
 keywords = ["datatest", "data-driven-tests", "test-harness"]
 
 [dependencies]
-libtest-mimic = "0.4.0"
+libtest-mimic = "0.5.2"
 regex = "1.5.4"
 walkdir = "2.3.2"
 

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ datatest_stable::harness!(my_test, "path/to/fixtures", r"^.*/*");
 
 ## Minimum supported Rust version (MSRV)
 
-The minimum supported Rust version is **Rust 1.56**. MSRV bumps may be accompanied by a minor
+The minimum supported Rust version is **Rust 1.58**. MSRV bumps may be accompanied by a minor
 version update; at any time, at least the last 3 stable versions of Rust will be supported.
 
 ## See also

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -53,7 +53,7 @@
 //!
 //! # Minimum supported Rust version (MSRV)
 //!
-//! The minimum supported Rust version is **Rust 1.56**. MSRV bumps may be accompanied by a minor
+//! The minimum supported Rust version is **Rust 1.58**. MSRV bumps may be accompanied by a minor
 //! version update; at any time, at least the last 3 stable versions of Rust will be supported.
 //!
 //! # See also

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -12,7 +12,7 @@ pub fn runner(requirements: &[Requirements]) {
     let args = Arguments::from_args();
 
     let mut tests: Vec<_> = requirements.iter().flat_map(|req| req.expand()).collect();
-    tests.sort_unstable_by(|a, b| a.name().cmp(&b.name()));
+    tests.sort_unstable_by(|a, b| a.name().cmp(b.name()));
 
     libtest_mimic::run(&args, tests).exit()
 }

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -4,7 +4,7 @@
 #![allow(clippy::integer_arithmetic)]
 
 use crate::{utils, Result};
-use libtest_mimic::{run_tests, Arguments, Outcome, Test};
+use libtest_mimic::{Arguments, Trial};
 use std::path::Path;
 
 #[doc(hidden)]
@@ -12,9 +12,9 @@ pub fn runner(requirements: &[Requirements]) {
     let args = Arguments::from_args();
 
     let mut tests: Vec<_> = requirements.iter().flat_map(|req| req.expand()).collect();
-    tests.sort_unstable_by(|a, b| a.name.cmp(&b.name));
+    tests.sort_unstable_by(|a, b| a.name().cmp(&b.name()));
 
-    run_tests(&args, tests, |test| (test.data)()).exit()
+    libtest_mimic::run(&args, tests).exit()
 }
 
 #[doc(hidden)]
@@ -43,7 +43,7 @@ impl Requirements {
 
     /// Scans all files in a given directory, finds matching ones and generates a test descriptor
     /// for each of them.
-    fn expand(&self) -> Vec<Test<Box<dyn Fn() -> Outcome + Send + Sync>>> {
+    fn expand(&self) -> Vec<Trial> {
         let root = Path::new(&self.root).to_path_buf();
 
         let re = regex::Regex::new(&self.pattern)
@@ -55,21 +55,10 @@ impl Requirements {
                 if re.is_match(&input_path) {
                     let testfn = self.test;
                     let name = utils::derive_test_name(&root, &path, &self.test_name);
-                    let testfn: Box<dyn Fn() -> Outcome + Send + Sync> =
-                        Box::new(move || match (testfn)(&path) {
-                            Ok(()) => Outcome::Passed,
-                            Err(err) => Outcome::Failed {
-                                msg: Some(format!("{}", err)),
-                            },
-                        });
 
-                    Some(Test {
-                        name,
-                        kind: String::new(),
-                        is_ignored: false,
-                        is_bench: false,
-                        data: testfn,
-                    })
+                    Some(Trial::test(name, move || {
+                        (testfn)(&path).map_err(Into::into)
+                    }))
                 } else {
                     None
                 }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -27,7 +27,6 @@ pub fn derive_test_name(root: &Path, path: &Path, test_name: &str) -> String {
             path.display()
         )
     });
-    let mut test_name = test_name.to_string();
-    test_name.push_str(&format!("::{}", relative.display()));
-    test_name
+
+    format!("{}::{}", test_name, relative.display())
 }


### PR DESCRIPTION
I just released [a new version of libtest-mimic](https://github.com/LukasKalbertodt/libtest-mimic/releases/tag/v0.5.0). This is one of the bigger libaries using it, so as a sanity check whether the new version still works for real world users, I just did this update. It allowed to remove some of the code here as the API changed a bit.

Two things to note:
- `libtest-mimic` requires Rust 1.58. 
- I do not know anything about this project and did not test anything except compiling and running the tests (via `cargo test`). Please review carefully and/or test.