### PR TITLE
Use {:?} for displaying errors

### DIFF
--- a/src/runner.rs
+++ b/src/runner.rs
@@ -59,7 +59,7 @@ impl Requirements {
                         Box::new(move || match (testfn)(&path) {
                             Ok(()) => Outcome::Passed,
                             Err(err) => Outcome::Failed {
-                                msg: Some(format!("{}", err)),
+                                msg: Some(format!("Error: {:?}", err)),
                             },
                         });
 


### PR DESCRIPTION
In the standard unit tests, if an `Err` is returned, the error chain and stacktrace (using `RUST_BACKTRACE=1`) is visible:
```
---- failing_test stdout ----
Error: outer

Caused by:
    inner (param1=important)
    
Stack backtrace:
   0: anyhow::error::<impl anyhow::Error>::msg
...
```

Using datatest_stable, only the following appears:
```
---- datatests::failing_test::x.txt ----
outer
```

Which is not as helpful as it could be, especially when using `anyhow`'s and `with_context`. The PR aims to fix this.