### PR TITLE
support tests that load files as strings or Vec<u8>

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,9 +6,12 @@
 [![License](https://img.shields.io/badge/license-Apache-green.svg)](../LICENSE-APACHE)
 [![License](https://img.shields.io/badge/license-MIT-green.svg)](../LICENSE-MIT)
 
-`datatest-stable` is a very simple test harness intended to write data-driven tests, where
-individual test cases are specified as files and not as code. Given:
-* a test `my_test` that accepts a path as input
+`datatest-stable` is a test harness intended to write *file-driven* or *data-driven* tests,
+where individual test cases are specified as files and not as code.
+
+Given:
+
+* a test `my_test` that accepts a path, and optionally the contents as input
 * a directory to look for files in
 * a pattern to match files on
 
@@ -29,10 +32,18 @@ harness = false
 
 2. Call the `datatest_stable::harness!(testfn, root, pattern)` macro with the following
 parameters:
-* `testfn` - The test function to be executed on each matching input. This function can be one of:
+
+* `testfn` - The test function to be executed on each matching input. This function can be one
+  of:
   * `fn(&Path) -> datatest_stable::Result<()>`
   * `fn(&Utf8Path) -> datatest_stable::Result<()>` (`Utf8Path` is part of the
      [`camino`](https://docs.rs/camino) library, and is re-exported here for convenience.)
+  * `fn(&P, String) -> datatest_stable::Result<()>` where `P` is `Path` or `Utf8Path`. If the
+    extra `String` parameter is specified, the contents of the file will be loaded and passed in
+    as a string (erroring out if that failed).
+  * `fn(&P, Vec<u8>) -> datatest_stable::Result<()>` where `P` is `Path` or `Utf8Path`. If the
+    extra `Vec<u8>` parameter is specified, are specified, the contents of the file will be
+    loaded and passed in as a `Vec<u8>` (erroring out if that failed).
 * `root` - The path to the root directory where the input files (fixtures) live. This path is
   relative to the root of the crate.
 * `pattern` - the regex used to match against and select each file to be tested.
@@ -54,7 +65,7 @@ fn my_test(path: &Path) -> datatest_stable::Result<()> {
     Ok(())
 }
 
-fn my_test_utf8(path: &Utf8Path) -> datatest_stable::Result<()> {
+fn my_test_utf8(path: &Utf8Path, contents: String) -> datatest_stable::Result<()> {
     // ... write test here
 
     Ok(())

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,9 +3,12 @@
 
 #![forbid(unsafe_code)]
 
-//! `datatest-stable` is a very simple test harness intended to write data-driven tests, where
-//! individual test cases are specified as files and not as code. Given:
-//! * a test `my_test` that accepts a path as input
+//! `datatest-stable` is a test harness intended to write *file-driven* or *data-driven* tests,
+//! where individual test cases are specified as files and not as code.
+//!
+//! Given:
+//!
+//! * a test `my_test` that accepts a path, and optionally the contents as input
 //! * a directory to look for files in
 //! * a pattern to match files on
 //!
@@ -26,10 +29,18 @@
 //!
 //! 2. Call the `datatest_stable::harness!(testfn, root, pattern)` macro with the following
 //! parameters:
-//! * `testfn` - The test function to be executed on each matching input. This function can be one of:
+//!
+//! * `testfn` - The test function to be executed on each matching input. This function can be one
+//!   of:
 //!   * `fn(&Path) -> datatest_stable::Result<()>`
 //!   * `fn(&Utf8Path) -> datatest_stable::Result<()>` (`Utf8Path` is part of the
 //!      [`camino`](https://docs.rs/camino) library, and is re-exported here for convenience.)
+//!   * `fn(&P, String) -> datatest_stable::Result<()>` where `P` is `Path` or `Utf8Path`. If the
+//!     extra `String` parameter is specified, the contents of the file will be loaded and passed in
+//!     as a string (erroring out if that failed).
+//!   * `fn(&P, Vec<u8>) -> datatest_stable::Result<()>` where `P` is `Path` or `Utf8Path`. If the
+//!     extra `Vec<u8>` parameter is specified, are specified, the contents of the file will be
+//!     loaded and passed in as a `Vec<u8>` (erroring out if that failed).
 //! * `root` - The path to the root directory where the input files (fixtures) live. This path is
 //!   relative to the root of the crate.
 //! * `pattern` - the regex used to match against and select each file to be tested.
@@ -51,7 +62,7 @@
 //!     Ok(())
 //! }
 //!
-//! fn my_test_utf8(path: &Utf8Path) -> datatest_stable::Result<()> {
+//! fn my_test_utf8(path: &Utf8Path, contents: String) -> datatest_stable::Result<()> {
 //!     // ... write test here
 //!
 //!     Ok(())
@@ -85,7 +96,7 @@ pub type Result<T> = std::result::Result<T, Box<dyn std::error::Error>>;
 
 /// Not part of the public API, just used for macros.
 #[doc(hidden)]
-pub use self::runner::{runner, Requirements, TestFn};
+pub use self::runner::{runner, test_kinds, Requirements, TestFn};
 /// A re-export of this type from the `camino` crate, since it forms part of function signatures.
 #[doc(no_inline)]
 pub use camino::Utf8Path;

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -10,11 +10,12 @@ macro_rules! harness {
     ( $( $name:path, $root:expr, $pattern:expr ),+ $(,)* ) => {
         fn main() -> ::std::process::ExitCode {
             let mut requirements = Vec::new();
+            use $crate::test_kinds::*;
 
             $(
                 requirements.push(
                     $crate::Requirements::new(
-                        $name,
+                        $name.kind().resolve($name),
                         stringify!($name).to_string(),
                         $root.to_string().into(),
                         $pattern.to_string()

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -107,14 +107,9 @@ pub struct Requirements {
 
 impl Requirements {
     #[doc(hidden)]
-    pub fn new<P: TestFnPath + ?Sized>(
-        test: fn(&P) -> Result<()>,
-        test_name: String,
-        root: Utf8PathBuf,
-        pattern: String,
-    ) -> Self {
+    pub fn new(test: TestFn, test_name: String, root: Utf8PathBuf, pattern: String) -> Self {
         Self {
-            test: P::convert(test),
+            test,
             test_name,
             root,
             pattern,
@@ -172,43 +167,276 @@ impl Requirements {
     }
 }
 
+// -- Polymorphic dispatch --
+
 #[derive(Clone, Copy)]
 #[doc(hidden)]
 pub enum TestFn {
-    Path(fn(&Path) -> Result<()>),
-    Utf8Path(fn(&Utf8Path) -> Result<()>),
-}
-
-mod private {
-    pub trait Sealed {}
-}
-
-#[doc(hidden)]
-pub trait TestFnPath: private::Sealed {
-    fn convert(f: fn(&Self) -> Result<()>) -> TestFn;
-}
-
-impl private::Sealed for Path {}
-
-impl TestFnPath for Path {
-    fn convert(f: fn(&Self) -> Result<()>) -> TestFn {
-        TestFn::Path(f)
-    }
-}
-
-impl private::Sealed for Utf8Path {}
-
-impl TestFnPath for Utf8Path {
-    fn convert(f: fn(&Self) -> Result<()>) -> TestFn {
-        TestFn::Utf8Path(f)
-    }
+    // Functions that work on paths.
+    Base(TestFnBase),
+    /// Test functions that load a file as a string (UTF-8 text).
+    LoadString(TestFnLoadString),
+    /// Test functions that load a file as binary data.
+    LoadBinary(TestFnLoadBinary),
 }
 
 impl TestFn {
     fn call(&self, path: &Utf8Path) -> Result<()> {
         match self {
-            TestFn::Path(f) => f(path.as_ref()),
-            TestFn::Utf8Path(f) => f(path),
+            TestFn::Base(f) => f.call(path),
+            TestFn::LoadString(f) => f.call(path),
+            TestFn::LoadBinary(f) => f.call(path),
         }
     }
+}
+
+#[derive(Clone, Copy)]
+#[doc(hidden)]
+pub enum TestFnBase {
+    Path(fn(&Path) -> Result<()>),
+    Utf8Path(fn(&Utf8Path) -> Result<()>),
+}
+
+impl TestFnBase {
+    fn call(&self, path: &Utf8Path) -> Result<()> {
+        match self {
+            TestFnBase::Path(f) => f(path.as_ref()),
+            TestFnBase::Utf8Path(f) => f(path),
+        }
+    }
+}
+
+#[derive(Clone, Copy)]
+#[doc(hidden)]
+pub enum TestFnLoadString {
+    Path(fn(&Path, String) -> Result<()>),
+    Utf8Path(fn(&Utf8Path, String) -> Result<()>),
+}
+
+impl TestFnLoadString {
+    fn call(&self, path: &Utf8Path) -> Result<()> {
+        let contents = std::fs::read_to_string(path)
+            .map_err(|err| format!("error reading file '{path}' as UTF-8: {err}"))?;
+        match self {
+            TestFnLoadString::Path(f) => f(path.as_ref(), contents),
+            TestFnLoadString::Utf8Path(f) => f(path, contents),
+        }
+    }
+}
+
+#[derive(Clone, Copy)]
+#[doc(hidden)]
+pub enum TestFnLoadBinary {
+    Path(fn(&Path, Vec<u8>) -> Result<()>),
+    Utf8Path(fn(&Utf8Path, Vec<u8>) -> Result<()>),
+}
+
+impl TestFnLoadBinary {
+    fn call(&self, path: &Utf8Path) -> Result<()> {
+        let contents =
+            std::fs::read(path).map_err(|err| format!("error reading file '{path}': {err}"))?;
+        match self {
+            TestFnLoadBinary::Path(f) => f(path.as_ref(), contents),
+            TestFnLoadBinary::Utf8Path(f) => f(path, contents),
+        }
+    }
+}
+
+/// Implementations to allow `TestFn` to be created with functions of one of several types.
+///
+/// datatest-stable supports several options for the shape of test functions. This code allows:
+///
+/// * the `harness!` macro to accept any of these types of functions, generating the same syntactic
+///   code for each.
+/// * for all of those functions to resolve to a single `TestFn` type which can do dynamic dispatch.
+///
+/// There are several challenges to overcome here, the main one being that you cannot have multiple
+/// different kinds of `Fn`s impl the same trait. For example, rustc will not accept this code
+/// ([playground](https://play.rust-lang.org/?version=stable&mode=debug&edition=2021&gist=007c814fb457bd4e95d0073745b5f8d9)):
+///
+/// ```rust,ignore
+/// trait MyTrait {}
+///
+/// impl<F: Fn(u32)> MyTrait for F {}
+/// impl<F: Fn(bool)> MyTrait for F {}
+/// ```
+///
+/// This means that it is not possible to write code that is type-system generic over different
+/// kinds of function types.
+///
+/// But since `harness!` is a macro, it can expand to code that's syntactically the same for each of
+/// those function types, but semantically resolves to completely different types. That's exactly
+/// what we do here.
+///
+/// This is a trick very similar to autoref specialization, though we don't use the automatic `&`
+/// Rust inserts while dereferencing methods. See [autoref-specialization].
+///
+/// # Notes
+///
+/// We can't say `impl PathKind for fn(&Path) -> Result<()>` because Rust won't automatically coerce
+/// the concrete function type to the function pointer. (If we could, then we wouldn't need to rely
+/// on the macro-ness of `harness!` at all, and could just have a single trait implemented for all
+/// the different function pointer types.) To address this, we use a two-step process.
+///
+/// * Step 1: Implement `PathKind` for all `F: Fn(&Path) -> Result<()>`. This allows a `.kind()`
+///   method to exist which returns a new `PathTag` type.
+/// * Step 2: Implement `PathTag::new` which only takes `fn(&Path) -> Result<()>`. *This* type can
+///   coerce to the function pointer, which can be stored in the `TestFn` enum.
+///
+/// This two-step process is similar to the one documented in [autoref-specialization].
+///
+/// [autoref-specialization]: https://github.com/dtolnay/case-studies/blob/master/autoref-specialization/README.md
+#[doc(hidden)]
+pub mod test_kinds {
+
+    use super::*;
+
+    mod private {
+        // We need to define a separate Sealed for each of the tags below, because Rust doesn't allow
+        // multiple kinds of F: Fn(T) -> Result<()> to implement the same trait.
+        pub trait PathSealed {}
+        pub trait Utf8PathSealed {}
+        pub trait PathStringSealed {}
+        pub trait Utf8PathStringSealed {}
+        pub trait PathBytesSealed {}
+        pub trait Utf8PathBytesSealed {}
+    }
+
+    // -- Paths --
+
+    #[doc(hidden)]
+    pub struct PathTag;
+
+    impl PathTag {
+        #[inline]
+        pub fn resolve(self, f: fn(&Path) -> Result<()>) -> TestFn {
+            TestFn::Base(TestFnBase::Path(f))
+        }
+    }
+
+    #[doc(hidden)]
+    pub trait PathKind: private::PathSealed {
+        #[inline]
+        fn kind(&self) -> PathTag {
+            PathTag
+        }
+    }
+
+    impl<F: Fn(&Path) -> Result<()>> private::PathSealed for F {}
+    impl<F: Fn(&Path) -> Result<()>> PathKind for F {}
+
+    // -- UTF-8 paths --
+
+    #[doc(hidden)]
+    pub struct Utf8PathTag;
+
+    impl Utf8PathTag {
+        #[inline]
+        pub fn resolve(&self, f: fn(&Utf8Path) -> Result<()>) -> TestFn {
+            TestFn::Base(TestFnBase::Utf8Path(f))
+        }
+    }
+
+    #[doc(hidden)]
+    pub trait Utf8PathKind: private::Utf8PathSealed {
+        #[inline]
+        fn kind(&self) -> Utf8PathTag {
+            Utf8PathTag
+        }
+    }
+
+    impl<F: Fn(&Utf8Path) -> Result<()>> private::Utf8PathSealed for F {}
+    impl<F: Fn(&Utf8Path) -> Result<()>> Utf8PathKind for F {}
+
+    // -- Path, load file as string --
+
+    #[doc(hidden)]
+    pub struct PathStringTag;
+
+    impl PathStringTag {
+        #[inline]
+        pub fn resolve(self, f: fn(&Path, String) -> Result<()>) -> TestFn {
+            TestFn::LoadString(TestFnLoadString::Path(f))
+        }
+    }
+
+    #[doc(hidden)]
+    pub trait PathStringKind: private::PathStringSealed {
+        #[inline]
+        fn kind(&self) -> PathStringTag {
+            PathStringTag
+        }
+    }
+
+    impl<F: Fn(&Path, String) -> Result<()>> private::PathStringSealed for F {}
+    impl<F: Fn(&Path, String) -> Result<()>> PathStringKind for F {}
+
+    // -- Utf8Path, load file as string --
+
+    #[doc(hidden)]
+    pub struct Utf8PathStringTag;
+
+    impl Utf8PathStringTag {
+        #[inline]
+        pub fn resolve(self, f: fn(&Utf8Path, String) -> Result<()>) -> TestFn {
+            TestFn::LoadString(TestFnLoadString::Utf8Path(f))
+        }
+    }
+
+    #[doc(hidden)]
+    pub trait Utf8PathStringKind: private::Utf8PathStringSealed {
+        #[inline]
+        fn kind(&self) -> Utf8PathStringTag {
+            Utf8PathStringTag
+        }
+    }
+
+    impl<F: Fn(&Utf8Path, String) -> Result<()>> private::Utf8PathStringSealed for F {}
+    impl<F: Fn(&Utf8Path, String) -> Result<()>> Utf8PathStringKind for F {}
+
+    // -- Path, load file as binary --
+
+    #[doc(hidden)]
+    pub struct PathBytesTag;
+
+    impl PathBytesTag {
+        #[inline]
+        pub fn resolve(self, f: fn(&Path, Vec<u8>) -> Result<()>) -> TestFn {
+            TestFn::LoadBinary(TestFnLoadBinary::Path(f))
+        }
+    }
+
+    #[doc(hidden)]
+    pub trait PathBytesKind: private::PathBytesSealed {
+        #[inline]
+        fn kind(&self) -> PathBytesTag {
+            PathBytesTag
+        }
+    }
+
+    impl<F: Fn(&Path, Vec<u8>) -> Result<()>> private::PathBytesSealed for F {}
+    impl<F: Fn(&Path, Vec<u8>) -> Result<()>> PathBytesKind for F {}
+
+    // -- Utf8Path, load file as binary --
+
+    #[doc(hidden)]
+    pub struct Utf8PathBytesTag;
+
+    impl Utf8PathBytesTag {
+        #[inline]
+        pub fn resolve(self, f: fn(&Utf8Path, Vec<u8>) -> Result<()>) -> TestFn {
+            TestFn::LoadBinary(TestFnLoadBinary::Utf8Path(f))
+        }
+    }
+
+    #[doc(hidden)]
+    pub trait Utf8PathBytesKind: private::Utf8PathBytesSealed {
+        #[inline]
+        fn kind(&self) -> Utf8PathBytesTag {
+            Utf8PathBytesTag
+        }
+    }
+
+    impl<F: Fn(&Utf8Path, Vec<u8>) -> Result<()>> private::Utf8PathBytesSealed for F {}
+    impl<F: Fn(&Utf8Path, Vec<u8>) -> Result<()>> Utf8PathBytesKind for F {}
 }

--- a/tests/example.rs
+++ b/tests/example.rs
@@ -17,11 +17,48 @@ fn test_artifact_utf8(path: &Utf8Path) -> Result<()> {
     test_artifact(path.as_ref())
 }
 
+fn test_artifact_string(path: &Path, contents: String) -> Result<()> {
+    compare_contents(path, contents.as_bytes())
+}
+
+fn test_artifact_utf8_string(path: &Utf8Path, contents: String) -> Result<()> {
+    compare_contents(path.as_std_path(), contents.as_bytes())
+}
+
+fn test_artifact_bytes(path: &Path, contents: Vec<u8>) -> Result<()> {
+    compare_contents(path, &contents)
+}
+
+fn test_artifact_utf8_bytes(path: &Utf8Path, contents: Vec<u8>) -> Result<()> {
+    compare_contents(path.as_std_path(), &contents)
+}
+
+fn compare_contents(path: &Path, expected: &[u8]) -> Result<()> {
+    let actual =
+        std::fs::read(path).map_err(|error| format!("failed to read file: {:?}: {error}", path))?;
+
+    assert_eq!(expected, &actual, "file contents match for {:?}", path);
+
+    Ok(())
+}
+
 datatest_stable::harness!(
     test_artifact,
     "tests/files",
     r"^.*(?<!\.skip)\.txt$", // this regex pattern skips .skip.txt files
     test_artifact_utf8,
     "tests/files",
-    r"^.*\.txt$", // this regexpattern matches all files
+    r"^.*\.txt$", // this regex pattern matches all files
+    test_artifact_string,
+    "tests/files",
+    r"^.*\.txt$",
+    test_artifact_utf8_string,
+    "tests/files",
+    r"^.*\.txt$",
+    test_artifact_bytes,
+    "tests/files",
+    r"^.*\.txt$",
+    test_artifact_utf8_bytes,
+    "tests/files",
+    r"^.*\.txt$",
 );

--- a/tests/run_example.rs
+++ b/tests/run_example.rs
@@ -2,11 +2,23 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
 static EXPECTED_LINES: &[&str] = &[
+    "datatest-stable::example test_artifact_bytes::a.txt",
+    "datatest-stable::example test_artifact_bytes::b.txt",
+    "datatest-stable::example test_artifact_bytes::c.skip.txt",
+    "datatest-stable::example test_artifact_string::a.txt",
+    "datatest-stable::example test_artifact_string::b.txt",
+    "datatest-stable::example test_artifact_string::c.skip.txt",
+    "datatest-stable::example test_artifact_utf8_bytes::a.txt",
+    "datatest-stable::example test_artifact_utf8_bytes::b.txt",
+    "datatest-stable::example test_artifact_utf8_bytes::c.skip.txt",
+    "datatest-stable::example test_artifact_utf8_string::a.txt",
+    "datatest-stable::example test_artifact_utf8_string::b.txt",
+    "datatest-stable::example test_artifact_utf8_string::c.skip.txt",
+    "datatest-stable::example test_artifact_utf8::a.txt",
+    "datatest-stable::example test_artifact_utf8::b.txt",
+    "datatest-stable::example test_artifact_utf8::c.skip.txt",
     "datatest-stable::example test_artifact::a.txt",
     "datatest-stable::example test_artifact::b.txt",
-    "datatest-stable::example test_artifact_utf8::a.txt",
-    "datatest-stable::example test_artifact_utf8::c.skip.txt",
-    "datatest-stable::example test_artifact_utf8::b.txt",
 ];
 
 #[test]
@@ -31,7 +43,7 @@ fn run_example() {
     for line in EXPECTED_LINES
         .iter()
         .copied()
-        .chain(std::iter::once("5 tests run: 5 passed, 0 skipped"))
+        .chain(std::iter::once("17 tests run: 17 passed, 0 skipped"))
     {
         assert!(
             stderr.contains(line),
@@ -46,10 +58,35 @@ mod unix {
     use camino_tempfile::Utf8TempDir;
 
     static EXPECTED_UNIX_LINES: &[&str] = &[
-        "datatest-stable::example test_artifact::::colon::dir/::.txt",
-        "datatest-stable::example test_artifact::::colon::dir/a.txt",
+        "datatest-stable::example test_artifact_bytes::::colon::dir/::.txt",
+        "datatest-stable::example test_artifact_bytes::::colon::dir/a.txt",
+        "datatest-stable::example test_artifact_bytes::a.txt",
+        "datatest-stable::example test_artifact_bytes::b.txt",
+        "datatest-stable::example test_artifact_bytes::c.skip.txt",
+        "datatest-stable::example test_artifact_string::::colon::dir/::.txt",
+        "datatest-stable::example test_artifact_string::::colon::dir/a.txt",
+        "datatest-stable::example test_artifact_string::a.txt",
+        "datatest-stable::example test_artifact_string::b.txt",
+        "datatest-stable::example test_artifact_string::c.skip.txt",
+        "datatest-stable::example test_artifact_utf8_bytes::::colon::dir/::.txt",
+        "datatest-stable::example test_artifact_utf8_bytes::::colon::dir/a.txt",
+        "datatest-stable::example test_artifact_utf8_bytes::a.txt",
+        "datatest-stable::example test_artifact_utf8_bytes::b.txt",
+        "datatest-stable::example test_artifact_utf8_bytes::c.skip.txt",
+        "datatest-stable::example test_artifact_utf8_string::::colon::dir/::.txt",
+        "datatest-stable::example test_artifact_utf8_string::::colon::dir/a.txt",
+        "datatest-stable::example test_artifact_utf8_string::a.txt",
+        "datatest-stable::example test_artifact_utf8_string::b.txt",
+        "datatest-stable::example test_artifact_utf8_string::c.skip.txt",
         "datatest-stable::example test_artifact_utf8::::colon::dir/::.txt",
         "datatest-stable::example test_artifact_utf8::::colon::dir/a.txt",
+        "datatest-stable::example test_artifact_utf8::a.txt",
+        "datatest-stable::example test_artifact_utf8::b.txt",
+        "datatest-stable::example test_artifact_utf8::c.skip.txt",
+        "datatest-stable::example test_artifact::::colon::dir/::.txt",
+        "datatest-stable::example test_artifact::::colon::dir/a.txt",
+        "datatest-stable::example test_artifact::a.txt",
+        "datatest-stable::example test_artifact::b.txt",
     ];
 
     #[test]
@@ -94,7 +131,7 @@ mod unix {
             .iter()
             .chain(EXPECTED_UNIX_LINES.iter())
             .copied()
-            .chain(std::iter::once("9 tests run: 9 passed, 0 skipped"))
+            .chain(std::iter::once("29 tests run: 29 passed, 0 skipped"))
         {
             assert!(
                 stderr.contains(line),


### PR DESCRIPTION
I realized that we could use a variant of autoref specialization to achieve this, and this seemed like a good way for me to learn how to do that as well. This is neat!